### PR TITLE
tweaks for R CMD CHECK

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,4 +10,5 @@ BugReports: https://github.com/GrahamDB/hzar/issues
 Description: A collection of tools for modeling the shape of 1 dimensional clines.
 License: GPL (>= 2)
 LazyLoad: yes
-Depends: R (>= 2.10.0), MCMCpack, foreach, coda, lattice
+Depends: R (>= 2.10.0)
+Imports: MCMCpack, foreach, coda, lattice

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -11,4 +11,4 @@ importFrom("stats", "cov.wt", "dt", "median", "na.omit", "quantile",
 importFrom("lattice", "equal.count")
 importFrom("foreach", "foreach", "%do%", "%dopar%")
 importFrom("MCMCpack", "MCMCmetrop1R")
-importFrom("coda", "as.mcmc", "mcmc", "thin")
+importFrom("coda", "as.mcmc", "mcmc", "thin", "mcmc.list")

--- a/R/30-hzarFitting.R
+++ b/R/30-hzarFitting.R
@@ -8,7 +8,7 @@ splitParameters<-function(paramList){
   param.free.lower =list();
   param.free.upper =list();
   for(iter in seq(along=paramList)){
-    if(class(paramList[[iter]])!="clineParameter")
+    if (!inherits(paramList[[iter]], "clineParameter"))
       stop(paste("Item",paramList[[iter]],"not a cline parameter!"));
     parName<-attr(paramList[[iter]],"param");
     parValue<-paramList[[iter]]$val;


### PR DESCRIPTION
With these tweaks, the package cleanly passes `R CMD CHECK` as run via `devtools::check()` on R 4.2.3 for Linux.

When I run the two example R files from the paper using the `foreach::registerDoSEQ()` option, I get sensible looking results with no errors.